### PR TITLE
Rev has-cors dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     }
   ],
   "dependencies": {
-    "has-cors": "1.0.3",
+    "has-cors": "1.1.0",
     "ws": "0.7.2",
     "xmlhttprequest-ssl": "1.5.1",
     "component-emitter": "1.1.2",


### PR DESCRIPTION
Revving the has-cors dep to 1.1.0.  Version 1.0.3 has a funky dep on a github version of the global module, which has been removed per component/has-cors#2, released at component/has-cors@27e9b96 . This would round out resolving the github dep issues under the socketio umbrella.
